### PR TITLE
fix: Pseudoterminal clear logic causes infinite recursion. 

### DIFF
--- a/src/playgroundTerminal.ts
+++ b/src/playgroundTerminal.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import * as child from 'child_process';
 import { SIGINT } from 'constants';
 
+const TERMINAL_RESET = '\x1bc\x1b[0J\x1b[1J\x1b[2J\x1b[3J\x1b[0;0H';
+
 export class PlaygroundTerminal {
     private static terminals: Record<string, PlaygroundTerminal> = {};
 
@@ -19,8 +21,14 @@ export class PlaygroundTerminal {
         const split = cwd.split("/");
         const slug = split[split.length - 1];
 
-        this.stdout = vscode.window.createTerminal({ name: `Rust Playground (${slug}) - stdout`, pty: new PlaygroundStdTerminal() });
-        this.stderr = vscode.window.createTerminal({ name: `Rust Playground (${slug}) - stderr`, pty: new PlaygroundErrTerminal() });
+        this.stdout = vscode.window.createTerminal({
+            name: `Rust Playground (${slug}) - stdout`,
+            pty: new PlaygroundPty('OUTPUT', 'Welcome to the Rust Playground. Try saving the open file'),
+        });
+        this.stderr = vscode.window.createTerminal({
+            name: `Rust Playground (${slug}) - stderr`,
+            pty: new PlaygroundPty('ERROR'),
+        });
 
         PlaygroundTerminal.terminals[cwd] = this;
     }
@@ -31,53 +39,56 @@ export class PlaygroundTerminal {
 
     private _stream: child.ChildProcessWithoutNullStreams | undefined = undefined;
     private onSave() {
-        const stdout = (this.stdout.creationOptions as vscode.ExtensionTerminalOptions).pty as PlaygroundStdTerminal;
-        const stderr = (this.stderr.creationOptions as vscode.ExtensionTerminalOptions).pty as PlaygroundErrTerminal;
+        const stderr = this.stderr;
+        const stdout = this.stdout;
+        const stderrpty = (stderr.creationOptions as vscode.ExtensionTerminalOptions).pty as PlaygroundPty;
+        const stdoutpty = (stdout.creationOptions as vscode.ExtensionTerminalOptions).pty as PlaygroundPty;
         this._stream?.kill();
 
-        stdout.clear();
-        stderr.clear();
+        stdoutpty.clear();
+        stderrpty.clear();
 
         this._stream = child.spawn("cargo", ["run",
             "--color", "always",
         ], { cwd: this.cwd });
 
-        this._stream.stdout.on("data", data => stdout.write(data));
-        this._stream.stderr.on("data", data => stderr.write(data));
+        this._stream.stdout.on("data", data => stdoutpty.write(data));
+        this._stream.stderr.on("data", data => stderrpty.write(data));
+        this._stream.on('error', err => {
+            stderrpty.write(Buffer.from(`\n!!!!!!!!!!! Could not start compile: ${err}\n`));
+            stderr.show(true);
+        });
+        this._stream.on('exit', exitCode => {
+          if (exitCode !== 0) {
+              stderrpty.write(Buffer.from(`\n!!!!!!!!!!! cargo run returned failure status: ${exitCode}\n`));
+              stderr.show(true);
+          } else {
+              stdout.show(true);
+          }
+        });
     }
 }
 
-
-export class PlaygroundStdTerminal implements vscode.Pseudoterminal {
+export class PlaygroundPty implements vscode.Pseudoterminal {
     private onDidWriteEmitter = new vscode.EventEmitter<string>();
+    private name: string;
+    private greeting?: string;
     onDidWrite = this.onDidWriteEmitter.event;
 
-    open(initialDimensions: vscode.TerminalDimensions | undefined): void { }
+    constructor(name: string, greeting?: string) {
+        this.name = name;
+        this.greeting = greeting;
+    }
+
+    open(): void {
+        if (!this.greeting) { return; }
+        this.onDidWriteEmitter.fire(this.greeting);
+    }
+
     close(): void { }
 
     clear() {
-        this.clear()
-        this.onDidWriteEmitter.fire('================ STANDARD OUTPUT ================\n\n\r');
-    }
-
-    write(data: Buffer) {
-        const output = data.toString().replace(/([^\r])\n/g, "$1\r\n");
-        this.onDidWriteEmitter.fire(output);
-    }
-}
-
-export class PlaygroundErrTerminal implements vscode.Pseudoterminal {
-    private onDidWriteEmitter = new vscode.EventEmitter<string>();
-    onDidWrite = this.onDidWriteEmitter.event;
-
-    open(initialDimensions: vscode.TerminalDimensions | undefined): void {
-        this.onDidWriteEmitter.fire("Welcome to the Rust Playground. Try saving the open file");
-    }
-    close(): void { }
-
-    clear() {
-        this.clear();
-        this.onDidWriteEmitter.fire('================ STANDARD  ERROR ================\n\n\r');
+        this.onDidWriteEmitter.fire(`${TERMINAL_RESET}================ STANDARD ${this.name} ================\n\n\r`);
     }
 
     write(data: Buffer) {


### PR DESCRIPTION
Right now, the extension cannot function at all because the `clear` method in the pseudoterminal classes is calling `this.clear()` which just recurses infinitely until the extension crashes. The fix is to just output terminal codes.

This pull also adds some other relatively minor improvements:

1. Refactored pseudoterminal classes to reduce code duplication.
2. Handle and report on errors and exit status for spawned cargo command.
3. Focus error terminal when command exits with failure or cannot start.

Closes #3